### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "reduce-reducers": "0.1.1",
     "redux": "3.3.0",
     "redux-thunk": "1.0.3",
-    "request": "2.65.0",
+    "request": "2.74.0",
     "reselect": "2.0.2"
   },
   "author": "",


### PR DESCRIPTION
sdr-bootstrap-prepack currently has a 4 vulnerable dependency paths, introducing 4 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/ipselon/sdr-bootstrap-prepack) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `express` and `moment` dependencies as well.

Stay Secure,
The Snyk Team
